### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,6 @@ class ItemsController < ApplicationController
   end
 
     def show
-      @item = Item.find(params[:id])
     end
     
     def edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,4 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index, :create]
   before_action :set_item, only: [:show, :edit, :update]
   before_action  :authenticate_user!, except: [:index]
   
@@ -45,11 +44,6 @@ class ItemsController < ApplicationController
   def items_params
     params.require(:item).permit(:text, :name, :image, :price, :category_id, 
     :prefecture_id, :condition_id, :days_id, :delivery_fee_id).merge(user_id: current_user.id)
-  end
-  def move_to_index
-    unless user_signed_in?
-      redirect_to action: :index
-    end
   end
   def set_item
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,9 @@
 class ItemsController < ApplicationController
+  before_action :move_to_index, except: [:index, :create]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action  :authenticate_user!, except: [:index]
   
-  skip_before_action  :authenticate_user!, only: [:index, :show]
-  
+
   def index
     @items = Item.order("created_at DESC")
   end
@@ -17,19 +19,41 @@ class ItemsController < ApplicationController
        @item.save
       return redirect_to root_path
     else
-      render 'new'
+      render :new
     end
   end
 
     def show
       @item = Item.find(params[:id])
     end
+    
+    def edit
+    end
 
+    def update
+      if @item.user_id == current_user.id
+        if @item.update(items_params)
+         redirect_to item_path(@item.id)
+        else
+          redirect_to action: :edit
+        end
+      else
+        redirect_to action: :edit
+      end
+    end
 
   private
   def items_params
     params.require(:item).permit(:text, :name, :image, :price, :category_id, 
     :prefecture_id, :condition_id, :days_id, :delivery_fee_id).merge(user_id: current_user.id)
+  end
+  def move_to_index
+    unless user_signed_in?
+      redirect_to action: :index
+    end
+  end
+  def set_item
+    @item = Item.find(params[:id])
   end
 end
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,11 +8,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <% render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -53,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:condition, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -74,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_fee, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:days, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:days_id, Days.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,14 +24,14 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% end %>
+    <% else %>
     <% if user_signed_in? && current_user.id != @item.user_id %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
-    
+    <% end%>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>


### PR DESCRIPTION
#What
商品情報（商品画像・商品名・商品の状態など）を変更できる
何も編集せずに更新をしても画像無しの商品にならない
出品者だけが編集ページに遷移できる
商品出品時とほぼ同じUIで編集機能が実装
商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること
エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させる）

#Why
商品情報編集機能実装のため


Gyazo Gif
https://gyazo.com/238921619ee0db5e67c7cf51a5f11563
https://gyazo.com/1cde82ecb3a9ddacd6c5f011e8261f7d